### PR TITLE
79 edit own contributions & 89 create reading page 

### DIFF
--- a/backend/src/controllers/project.controller.test.ts
+++ b/backend/src/controllers/project.controller.test.ts
@@ -174,7 +174,7 @@ describe("project.controller Fehlerfälle", () => {
     });
 
     expect(res.status).toBe(400);
-    expect(res.body).toHaveProperty("error", "Alle Felder sind erforderlich");
+    expect(res.body).toHaveProperty("error", "Alle Pflichtfelder (name, username, projectStructure) sind erforderlich");
   });
 
   it("POST /api/projects save() Fehler gibt 500 zurück", async () => {

--- a/backend/src/controllers/project.controller.test.ts
+++ b/backend/src/controllers/project.controller.test.ts
@@ -174,7 +174,10 @@ describe("project.controller Fehlerfälle", () => {
     });
 
     expect(res.status).toBe(400);
-    expect(res.body).toHaveProperty("error", "Alle Pflichtfelder (name, username, projectStructure) sind erforderlich");
+    expect(res.body).toHaveProperty(
+      "error",
+      "Alle Pflichtfelder (name, username, projectStructure) sind erforderlich",
+    );
   });
 
   it("POST /api/projects save() Fehler gibt 500 zurück", async () => {
@@ -232,15 +235,17 @@ describe("project.controller Fehlerfälle", () => {
   });
 
   // --- UPDATE ---
-  it("PUT /api/projects/:id ohne alle Felder gibt 400 zurück", async () => {
+  it("PUT /api/projects/:id ohne alle Felder gibt 200 zurück (angepasst an Controller)", async () => {
     const res = await request(app).put("/api/projects/1").send({
       name: "Project1",
       username: "user1",
       // projectStructure fehlt
     });
 
-    expect(res.status).toBe(400);
-    expect(res.body).toHaveProperty("error", "All fields are required");
+    expect(res.status).toBe(200);
+    // Optional: Prüfen, ob das zurückgegebene Objekt die erwarteten Felder enthält
+    expect(res.body).toHaveProperty("name", "UpdatedProject");
+    expect(res.body).toHaveProperty("username", "user1");
   });
 
   it("PUT /api/projects/:id nicht gefunden gibt 404 zurück", async () => {

--- a/backend/src/controllers/project.controller.ts
+++ b/backend/src/controllers/project.controller.ts
@@ -84,20 +84,16 @@ export const updateProject = async (req: Request, res: Response): Promise<void> 
     return;
   }
 
+  // Pflichtfelder prüfen
+  if (!name || !username || !projectStructure) {
+    res.status(400).json({ error: "All fields are required" });
+    return;
+  }
+
   try {
     const updatedProject = await Project.findOneAndUpdate(
       { _id: id },
-      {
-        ...(name && { name }),
-        ...(username && { username }),
-        ...(projectStructure && { projectStructure }),
-        ...(typeof isPublic !== "undefined" && { isPublic }),
-        ...(tags && { tags }),
-        ...(titleCommunityPage && { titleCommunityPage }),
-        ...(category && { category }),
-        ...(typeOfDocument && { typeOfDocument }),
-        ...(authorName && { authorName }),
-      },
+      { name, username, projectStructure, isPublic, tags, titleCommunityPage, category, typeOfDocument, authorName },
       { new: true }
     );
 
@@ -112,6 +108,7 @@ export const updateProject = async (req: Request, res: Response): Promise<void> 
     res.status(500).json({ error: "Internal Server Error" });
   }
 };
+
 
 
 // Get all projects by username

--- a/backend/src/controllers/project.controller.ts
+++ b/backend/src/controllers/project.controller.ts
@@ -21,12 +21,10 @@ export const createProject = async (
   } = req.body;
 
   if (!name || !username || !projectStructure) {
-    res
-      .status(400)
-      .json({
-        error:
-          "Alle Pflichtfelder (name, username, projectStructure) sind erforderlich",
-      });
+    res.status(400).json({
+      error:
+        "Alle Pflichtfelder (name, username, projectStructure) sind erforderlich",
+    });
     return;
   }
 

--- a/backend/src/controllers/project.controller.ts
+++ b/backend/src/controllers/project.controller.ts
@@ -4,23 +4,25 @@ import NodeContent from "../models/NodeContent";
 import AiProtocol from "../models/AIProtocol";
 
 // Create a new Project entry
-export const createProject = async (
-  req: Request,
-  res: Response,
-): Promise<void> => {
-  const { name, username, projectStructure } = req.body;
+export const createProject = async (req: Request, res: Response): Promise<void> => {
+  const { name, username, projectStructure, isPublic, tags, titleCommunityPage, category, typeOfDocument, authorName } = req.body;
 
   if (!name || !username || !projectStructure) {
-    res.status(400).json({ error: "Alle Felder sind erforderlich" });
+    res.status(400).json({ error: "Alle Pflichtfelder (name, username, projectStructure) sind erforderlich" });
     return;
   }
 
   try {
-    // Save the project with projectStructure as an object (not a string)
     const newProject = new Project({
       name,
       username,
-      projectStructure, // projectStructure is stored as an object
+      projectStructure,
+      isPublic: isPublic ?? false, // falls nicht mitgeschickt → default false
+      tags: tags ?? [],
+      titleCommunityPage: titleCommunityPage ?? "",
+      category: category ?? "",
+      typeOfDocument: typeOfDocument ?? "",
+      authorName: authorName ?? "", // Optional: Name des Autors
     });
 
     const savedProject = await newProject.save();
@@ -73,23 +75,30 @@ export const getAllProjects = async (
 };
 
 // Update a specific project entry by ID
-export const updateProject = async (
-  req: Request,
-  res: Response,
-): Promise<void> => {
+export const updateProject = async (req: Request, res: Response): Promise<void> => {
   const { id } = req.params;
-  const { name, username, projectStructure } = req.body;
+  const { name, username, projectStructure, isPublic, tags, titleCommunityPage, category, typeOfDocument, authorName } = req.body;
 
-  if (!id || !name || !username || !projectStructure) {
-    res.status(400).json({ error: "All fields are required" });
+  if (!id) {
+    res.status(400).json({ error: "Project ID is required" });
     return;
   }
 
   try {
     const updatedProject = await Project.findOneAndUpdate(
-      { _id: id }, // Verwende _id statt id als Mongoose ID
-      { name, username, projectStructure: projectStructure || [] }, // Falls projectStructure nicht übergeben wurde, leer lassen
-      { new: true },
+      { _id: id },
+      {
+        ...(name && { name }),
+        ...(username && { username }),
+        ...(projectStructure && { projectStructure }),
+        ...(typeof isPublic !== "undefined" && { isPublic }),
+        ...(tags && { tags }),
+        ...(titleCommunityPage && { titleCommunityPage }),
+        ...(category && { category }),
+        ...(typeOfDocument && { typeOfDocument }),
+        ...(authorName && { authorName }),
+      },
+      { new: true }
     );
 
     if (!updatedProject) {
@@ -103,6 +112,7 @@ export const updateProject = async (
     res.status(500).json({ error: "Internal Server Error" });
   }
 };
+
 
 // Get all projects by username
 export const getProjectsByUsername = async (

--- a/backend/src/controllers/project.controller.ts
+++ b/backend/src/controllers/project.controller.ts
@@ -4,11 +4,29 @@ import NodeContent from "../models/NodeContent";
 import AiProtocol from "../models/AIProtocol";
 
 // Create a new Project entry
-export const createProject = async (req: Request, res: Response): Promise<void> => {
-  const { name, username, projectStructure, isPublic, tags, titleCommunityPage, category, typeOfDocument, authorName } = req.body;
+export const createProject = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
+  const {
+    name,
+    username,
+    projectStructure,
+    isPublic,
+    tags,
+    titleCommunityPage,
+    category,
+    typeOfDocument,
+    authorName,
+  } = req.body;
 
   if (!name || !username || !projectStructure) {
-    res.status(400).json({ error: "Alle Pflichtfelder (name, username, projectStructure) sind erforderlich" });
+    res
+      .status(400)
+      .json({
+        error:
+          "Alle Pflichtfelder (name, username, projectStructure) sind erforderlich",
+      });
     return;
   }
 
@@ -75,26 +93,43 @@ export const getAllProjects = async (
 };
 
 // Update a specific project entry by ID
-export const updateProject = async (req: Request, res: Response): Promise<void> => {
+export const updateProject = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
   const { id } = req.params;
-  const { name, username, projectStructure, isPublic, tags, titleCommunityPage, category, typeOfDocument, authorName } = req.body;
+  const {
+    name,
+    username,
+    projectStructure,
+    isPublic,
+    tags,
+    titleCommunityPage,
+    category,
+    typeOfDocument,
+    authorName,
+  } = req.body;
 
   if (!id) {
     res.status(400).json({ error: "Project ID is required" });
     return;
   }
 
-  // Pflichtfelder prüfen
-  if (!name || !username || !projectStructure) {
-    res.status(400).json({ error: "All fields are required" });
-    return;
-  }
-
   try {
     const updatedProject = await Project.findOneAndUpdate(
       { _id: id },
-      { name, username, projectStructure, isPublic, tags, titleCommunityPage, category, typeOfDocument, authorName },
-      { new: true }
+      {
+        ...(name && { name }),
+        ...(username && { username }),
+        ...(projectStructure && { projectStructure }),
+        ...(typeof isPublic !== "undefined" && { isPublic }),
+        ...(tags && { tags }),
+        ...(titleCommunityPage && { titleCommunityPage }),
+        ...(category && { category }),
+        ...(typeOfDocument && { typeOfDocument }),
+        ...(authorName && { authorName }),
+      },
+      { new: true },
     );
 
     if (!updatedProject) {
@@ -108,8 +143,6 @@ export const updateProject = async (req: Request, res: Response): Promise<void> 
     res.status(500).json({ error: "Internal Server Error" });
   }
 };
-
-
 
 // Get all projects by username
 export const getProjectsByUsername = async (

--- a/backend/src/models/Project.ts
+++ b/backend/src/models/Project.ts
@@ -19,7 +19,7 @@ const projectSchema: Schema = new Schema(
     name: { type: String, required: true },
     username: { type: String, required: true },
     projectStructure: { type: Schema.Types.Mixed, required: true }, // Store JSON object directly
-    
+
     // neue Felder:
     isPublic: { type: Boolean, default: false }, // default = private
     tags: { type: [String], default: [] },

--- a/backend/src/models/Project.ts
+++ b/backend/src/models/Project.ts
@@ -4,6 +4,12 @@ export interface IProject extends Document {
   name: string;
   username: string;
   projectStructure: object;
+  isPublic: boolean; // neu: public/private toggle
+  tags?: string[]; // neu: Tags
+  titleCommunityPage?: string; // neu: Community Page Title
+  category?: string; // neu: Kategorie
+  typeOfDocument?: string; // neu: Dokumenttyp
+  authorName?: string; // Optional: Name des Autors
   created_at?: Date;
   updated_at?: Date;
 }
@@ -13,9 +19,17 @@ const projectSchema: Schema = new Schema(
     name: { type: String, required: true },
     username: { type: String, required: true },
     projectStructure: { type: Schema.Types.Mixed, required: true }, // Store JSON object directly
+    
+    // neue Felder:
+    isPublic: { type: Boolean, default: false }, // default = private
+    tags: { type: [String], default: [] },
+    titleCommunityPage: { type: String, default: "" },
+    category: { type: String, default: "" },
+    typeOfDocument: { type: String, default: "" },
+    authorName: { type: String, default: "" }, // Optional: Name des Autors
   },
   {
-    timestamps: true, // Automatically manage created_at and updated_at
+    timestamps: true, // created_at + updated_at automatisch
   },
 );
 

--- a/src/AppRoutes/AppRoutes.tsx
+++ b/src/AppRoutes/AppRoutes.tsx
@@ -24,6 +24,7 @@ import EditPage from "../pages/EditPage/EditPage";
 import SignInPage from "../pages/SignInPage/SignInPage";
 import SignUpPage from "../pages/SignUpPage/SignUpPage";
 import ProjectOverview from "../pages/ProjectOverview/ProjectOverview";
+import ReadingPage from "../pages/ReadingPage/ReadingPage";
 
 /*
  * AllRoutes Component
@@ -42,6 +43,7 @@ function AllRoutes(isSignedIn: boolean) {
       <Route path="/home" element={<HomePage />} />
       <Route path="/edit" element={<EditPage />} />
       <Route path="/edit/:projectId" element={<EditPage />} />
+      <Route path="/read/:projectId" element={<ReadingPage />} />
       <Route path="/structureSelection" element={<StructureSelectionPage />} />
       <Route path="/myProjects" element={<ProjectOverview />} />
 
@@ -71,15 +73,16 @@ export default function AppRoutes() {
     "/edit",
     "/structureSelection",
     "/myProjects",
+    "/read",
   ];
 
   // 2)
   const isPublicPath = publicPaths.some((p) =>
-    p === "/" ? pathname === "/" : pathname.startsWith(p),
+    p === "/" ? pathname === "/" : pathname.startsWith(p)
   );
 
   const isProtectedPath = protectedPaths.some((p) =>
-    p === "/" ? pathname === "/" : pathname.startsWith(p),
+    p === "/" ? pathname === "/" : pathname.startsWith(p)
   );
 
   // Wait for Clerk to load before rendering routes

--- a/src/AppRoutes/AppRoutes.tsx
+++ b/src/AppRoutes/AppRoutes.tsx
@@ -78,11 +78,11 @@ export default function AppRoutes() {
 
   // 2)
   const isPublicPath = publicPaths.some((p) =>
-    p === "/" ? pathname === "/" : pathname.startsWith(p)
+    p === "/" ? pathname === "/" : pathname.startsWith(p),
   );
 
   const isProtectedPath = protectedPaths.some((p) =>
-    p === "/" ? pathname === "/" : pathname.startsWith(p)
+    p === "/" ? pathname === "/" : pathname.startsWith(p),
   );
 
   // Wait for Clerk to load before rendering routes

--- a/src/components/BottomNavigationBar/BottomNavigationBar.test.tsx
+++ b/src/components/BottomNavigationBar/BottomNavigationBar.test.tsx
@@ -16,7 +16,7 @@ describe("BottomNavigationBar Unit Tests", () => {
         activeView="ai"
         onChangeView={onChangeViewMock}
         menuOpen={false}
-      />
+      />,
     );
 
     expect(screen.getByTitle(/AI Protocol/i)).toBeInTheDocument();
@@ -30,7 +30,7 @@ describe("BottomNavigationBar Unit Tests", () => {
         activeView="fullDocument"
         onChangeView={onChangeViewMock}
         menuOpen={false}
-      />
+      />,
     );
 
     const activeButton = screen.getByTitle(/Full Document View/i);
@@ -48,7 +48,7 @@ describe("BottomNavigationBar Unit Tests", () => {
         activeView="ai"
         onChangeView={onChangeViewMock}
         menuOpen={false}
-      />
+      />,
     );
 
     const contributionButton = screen.getByTitle(/Contribution View/i);
@@ -64,7 +64,7 @@ describe("BottomNavigationBar Unit Tests", () => {
         activeView="ai"
         onChangeView={onChangeViewMock}
         menuOpen={true}
-      />
+      />,
     );
 
     expect(container.firstChild).toHaveClass("flex justify-around");
@@ -76,7 +76,7 @@ describe("BottomNavigationBar Unit Tests", () => {
         activeView="ai"
         onChangeView={onChangeViewMock}
         menuOpen={false}
-      />
+      />,
     );
 
     expect(container.firstChild).toHaveClass("flex flex-col items-center");
@@ -94,7 +94,7 @@ describe("BottomNavigationBar Mutation Coverage Tests", () => {
           activeView={activeView}
           onChangeView={onChangeViewMock}
           menuOpen={false}
-        />
+        />,
       );
 
       views.forEach((view) => {
@@ -103,7 +103,7 @@ describe("BottomNavigationBar Mutation Coverage Tests", () => {
             ? /AI Protocol/i
             : view === "fullDocument"
               ? /Full Document View/i
-              : /Contribution View/i
+              : /Contribution View/i,
         );
 
         if (view === activeView) {
@@ -123,7 +123,7 @@ describe("BottomNavigationBar Mutation Coverage Tests", () => {
         activeView="ai"
         onChangeView={onChangeViewMock}
         menuOpen={false}
-      />
+      />,
     );
 
     const aiButton = screen.getByTitle(/AI Protocol/i);
@@ -147,7 +147,7 @@ describe("BottomNavigationBar Mutation Coverage Tests", () => {
         activeView="ai"
         onChangeView={onChangeViewMock}
         menuOpen={true}
-      />
+      />,
     );
     expect(container.firstChild).toHaveClass("flex justify-around");
   });
@@ -159,7 +159,7 @@ describe("BottomNavigationBar Mutation Coverage Tests", () => {
         activeView="ai"
         onChangeView={onChangeViewMock}
         menuOpen={false}
-      />
+      />,
     );
     expect(container.firstChild).toHaveClass("flex flex-col items-center");
   });

--- a/src/components/BottomNavigationBar/BottomNavigationBar.test.tsx
+++ b/src/components/BottomNavigationBar/BottomNavigationBar.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import BottomNavigationBar from "./BottomNavigationBar";
+import { vi } from "vitest";
 
 describe("BottomNavigationBar Unit Tests", () => {
   const onChangeViewMock = vi.fn();
@@ -15,12 +16,12 @@ describe("BottomNavigationBar Unit Tests", () => {
         activeView="ai"
         onChangeView={onChangeViewMock}
         menuOpen={false}
-      />,
+      />
     );
 
     expect(screen.getByTitle(/AI Protocol/i)).toBeInTheDocument();
     expect(screen.getByTitle(/Full Document View/i)).toBeInTheDocument();
-    expect(screen.getByTitle(/Share Document/i)).toBeInTheDocument();
+    expect(screen.getByTitle(/Contribution View/i)).toBeInTheDocument();
   });
 
   test("active button receives correct classes", () => {
@@ -29,7 +30,7 @@ describe("BottomNavigationBar Unit Tests", () => {
         activeView="fullDocument"
         onChangeView={onChangeViewMock}
         menuOpen={false}
-      />,
+      />
     );
 
     const activeButton = screen.getByTitle(/Full Document View/i);
@@ -47,14 +48,14 @@ describe("BottomNavigationBar Unit Tests", () => {
         activeView="ai"
         onChangeView={onChangeViewMock}
         menuOpen={false}
-      />,
+      />
     );
 
-    const shareButton = screen.getByTitle(/Share Document/i);
-    await user.click(shareButton);
+    const contributionButton = screen.getByTitle(/Contribution View/i);
+    await user.click(contributionButton);
 
     expect(onChangeViewMock).toHaveBeenCalledTimes(1);
-    expect(onChangeViewMock).toHaveBeenCalledWith("share");
+    expect(onChangeViewMock).toHaveBeenCalledWith("contribution");
   });
 
   test("menuOpen true applies the correct container class", () => {
@@ -63,7 +64,7 @@ describe("BottomNavigationBar Unit Tests", () => {
         activeView="ai"
         onChangeView={onChangeViewMock}
         menuOpen={true}
-      />,
+      />
     );
 
     expect(container.firstChild).toHaveClass("flex justify-around");
@@ -75,7 +76,7 @@ describe("BottomNavigationBar Unit Tests", () => {
         activeView="ai"
         onChangeView={onChangeViewMock}
         menuOpen={false}
-      />,
+      />
     );
 
     expect(container.firstChild).toHaveClass("flex flex-col items-center");
@@ -83,7 +84,7 @@ describe("BottomNavigationBar Unit Tests", () => {
 });
 
 describe("BottomNavigationBar Mutation Coverage Tests", () => {
-  const views = ["ai", "fullDocument", "share"] as const;
+  const views = ["ai", "fullDocument", "contribution"] as const;
 
   views.forEach((activeView) => {
     test(`renders correctly with activeView="${activeView}"`, () => {
@@ -93,7 +94,7 @@ describe("BottomNavigationBar Mutation Coverage Tests", () => {
           activeView={activeView}
           onChangeView={onChangeViewMock}
           menuOpen={false}
-        />,
+        />
       );
 
       views.forEach((view) => {
@@ -102,7 +103,7 @@ describe("BottomNavigationBar Mutation Coverage Tests", () => {
             ? /AI Protocol/i
             : view === "fullDocument"
               ? /Full Document View/i
-              : /Share Document/i,
+              : /Contribution View/i
         );
 
         if (view === activeView) {
@@ -122,21 +123,21 @@ describe("BottomNavigationBar Mutation Coverage Tests", () => {
         activeView="ai"
         onChangeView={onChangeViewMock}
         menuOpen={false}
-      />,
+      />
     );
 
     const aiButton = screen.getByTitle(/AI Protocol/i);
     const fullButton = screen.getByTitle(/Full Document View/i);
-    const shareButton = screen.getByTitle(/Share Document/i);
+    const contributionButton = screen.getByTitle(/Contribution View/i);
 
     await user.click(aiButton);
     await user.click(fullButton);
-    await user.click(shareButton);
+    await user.click(contributionButton);
 
     expect(onChangeViewMock).toHaveBeenCalledTimes(3);
     expect(onChangeViewMock).toHaveBeenCalledWith("ai");
     expect(onChangeViewMock).toHaveBeenCalledWith("fullDocument");
-    expect(onChangeViewMock).toHaveBeenCalledWith("share");
+    expect(onChangeViewMock).toHaveBeenCalledWith("contribution");
   });
 
   test("renders correctly when menuOpen is true", () => {
@@ -146,7 +147,7 @@ describe("BottomNavigationBar Mutation Coverage Tests", () => {
         activeView="ai"
         onChangeView={onChangeViewMock}
         menuOpen={true}
-      />,
+      />
     );
     expect(container.firstChild).toHaveClass("flex justify-around");
   });
@@ -158,7 +159,7 @@ describe("BottomNavigationBar Mutation Coverage Tests", () => {
         activeView="ai"
         onChangeView={onChangeViewMock}
         menuOpen={false}
-      />,
+      />
     );
     expect(container.firstChild).toHaveClass("flex flex-col items-center");
   });

--- a/src/components/BottomNavigationBar/BottomNavigationBar.tsx
+++ b/src/components/BottomNavigationBar/BottomNavigationBar.tsx
@@ -26,8 +26,8 @@ const BottomNavigationBar = ({
     },
     {
       icon: <Upload className="w-5 h-5" />,
-      view: "share",
-      label: "Share Document",
+      view: "contribution",
+      label: "Contribution View",
     },
   ];
 

--- a/src/components/ContributionCard/ContributionCard.test.tsx
+++ b/src/components/ContributionCard/ContributionCard.test.tsx
@@ -29,7 +29,7 @@ const renderWithRouter = (projectId: string) => {
       <Routes>
         <Route path="/projects/:projectId" element={<ContributionCard />} />
       </Routes>
-    </MemoryRouter>
+    </MemoryRouter>,
   );
 };
 
@@ -89,7 +89,7 @@ describe("ContributionCard", () => {
         "1",
         expect.objectContaining({
           titleCommunityPage: "Updated Title",
-        })
+        }),
       );
     });
   });
@@ -148,7 +148,7 @@ describe("ContributionCard", () => {
     await waitFor(() => {
       expect(ProjectService.updateProject).toHaveBeenCalledWith(
         "1",
-        expect.objectContaining({ authorName: "Anonymous" })
+        expect.objectContaining({ authorName: "Anonymous" }),
       );
     });
   });

--- a/src/components/ContributionCard/ContributionCard.test.tsx
+++ b/src/components/ContributionCard/ContributionCard.test.tsx
@@ -8,7 +8,7 @@ import { Project } from "../../utils/types";
 
 // Mock Project
 const mockProject: Project = {
-  id: "1",
+  _id: "1",
   name: "Test Project",
   projectStructure: [],
   isPublic: true,
@@ -21,7 +21,13 @@ const mockProject: Project = {
 };
 
 vi.spyOn(ProjectService, "getProjectById").mockResolvedValue(mockProject);
-vi.spyOn(ProjectService, "updateProject").mockResolvedValue({});
+vi.spyOn(ProjectService, "updateProject").mockResolvedValue({
+  _id: "1",
+  name: "Test",
+  username: "alice",
+  projectStructure: [],
+  isPublic: true,
+});
 
 const renderWithRouter = (projectId: string) => {
   return render(
@@ -184,7 +190,7 @@ describe("ContributionCard", () => {
     renderWithRouter("1");
 
     // Tags zählen vor Add-Versuch anhand spezifischer Klasse im Container (z.B. bg-purple-200)
-    const tagsBefore = screen.queryAllByText((content, element) => {
+    const tagsBefore = screen.queryAllByText((_, element) => {
       return (
         !!element &&
         element.classList &&
@@ -199,7 +205,7 @@ describe("ContributionCard", () => {
     await user.click(addBtn);
 
     // Tags zählen nach Add-Versuch
-    const tagsAfter = screen.queryAllByText((content, element) => {
+    const tagsAfter = screen.queryAllByText((_, element) => {
       return (
         !!element &&
         element.classList &&

--- a/src/components/ContributionCard/ContributionCard.test.tsx
+++ b/src/components/ContributionCard/ContributionCard.test.tsx
@@ -1,0 +1,212 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import ContributionCard from "./ContributionCard";
+import { ProjectService } from "../../utils/ProjectService";
+import { Project } from "../../utils/types";
+
+// Mock Project
+const mockProject: Project = {
+  id: "1",
+  name: "Test Project",
+  projectStructure: [],
+  isPublic: true,
+  titleCommunityPage: "Community Title",
+  category: "Computer Science",
+  typeOfDocument: "Bachelor Thesis",
+  tags: [],
+  username: "TestUser",
+  authorName: "TestUser",
+};
+
+vi.spyOn(ProjectService, "getProjectById").mockResolvedValue(mockProject);
+vi.spyOn(ProjectService, "updateProject").mockResolvedValue({});
+
+const renderWithRouter = (projectId: string) => {
+  return render(
+    <MemoryRouter initialEntries={[`/projects/${projectId}`]}>
+      <Routes>
+        <Route path="/projects/:projectId" element={<ContributionCard />} />
+      </Routes>
+    </MemoryRouter>
+  );
+};
+
+describe("ContributionCard", () => {
+  test("renders loading initially", () => {
+    renderWithRouter("1");
+    expect(screen.getByText(/Loading project/i)).toBeInTheDocument();
+  });
+
+  test("renders project fields after load", async () => {
+    renderWithRouter("1");
+
+    // Warte, bis das Community Title Input sichtbar ist
+    const titleInput =
+      await screen.findByPlaceholderText(/Community Page Title/i);
+    expect(titleInput).toBeInTheDocument();
+
+    expect(screen.getByDisplayValue("Community Title")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Computer Science")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Bachelor Thesis")).toBeInTheDocument();
+  });
+
+  test("add and remove tags", async () => {
+    const user = userEvent.setup();
+    renderWithRouter("1");
+
+    // Warte auf das Tag-Input
+    const input = await screen.findByPlaceholderText("Add Tag");
+    await user.type(input, "newTag");
+
+    const addBtn = screen.getByText("Add");
+    await user.click(addBtn);
+
+    // Prüfe, ob Tag hinzugefügt wurde
+    expect(screen.getByText("newTag")).toBeInTheDocument();
+
+    // Entferne Tag
+    const removeButtons = screen.getAllByText("✕", { selector: "button" });
+    await user.click(removeButtons[0]);
+    expect(screen.queryByText("newTag")).not.toBeInTheDocument();
+  });
+
+  test("save button calls updateProject", async () => {
+    const user = userEvent.setup();
+    renderWithRouter("1");
+
+    const titleInput =
+      await screen.findByPlaceholderText(/Community Page Title/i);
+    await user.clear(titleInput);
+    await user.type(titleInput, "Updated Title");
+
+    const saveButton = screen.getByText(/Update Project/i);
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(ProjectService.updateProject).toHaveBeenCalledWith(
+        "1",
+        expect.objectContaining({
+          titleCommunityPage: "Updated Title",
+        })
+      );
+    });
+  });
+
+  test("toggles visibility between public and private", async () => {
+    renderWithRouter("1");
+    await screen.findByPlaceholderText(/Community Page Title/i);
+
+    // Finde das Public/Private Label
+    const publicState = screen
+      .getAllByText("Public")
+      .find((node) => node.className.includes("font-medium"))!;
+    const label = publicState.closest("label")!;
+    const toggleDiv = label.querySelector(".w-16") as HTMLElement;
+
+    // Sollte "Public" starten
+    expect(publicState).toHaveTextContent("Public");
+
+    // Toggle klicken
+    toggleDiv.click();
+
+    // Jetzt warten, bis sich der Text auf "Private" geändert hat!
+    await waitFor(() => {
+      const privateState = screen
+        .getAllByText("Private")
+        .find((node) => node.className.includes("font-medium"));
+      expect(privateState).toBeTruthy();
+      expect(privateState).toHaveTextContent("Private");
+    });
+  });
+
+  test("save button is enabled when changes are valid", async () => {
+    const user = userEvent.setup();
+    renderWithRouter("1");
+    const titleInput =
+      await screen.findByPlaceholderText(/Community Page Title/i);
+
+    await user.clear(titleInput);
+    await user.type(titleInput, "Changed Title");
+    const saveButton = screen.getByText(/Update Project/i);
+    expect(saveButton.closest("div")).not.toHaveClass("opacity-40");
+  });
+
+  test("anonymous checkbox updates authorName", async () => {
+    const user = userEvent.setup();
+    renderWithRouter("1");
+
+    const checkbox = await screen.findByLabelText(/Post as Anonymous/i);
+    expect(checkbox).not.toBeChecked();
+    await user.click(checkbox);
+    expect(checkbox).toBeChecked();
+
+    // Save and check call
+    const saveButton = screen.getByText(/Update Project/i);
+    await user.click(saveButton);
+    await waitFor(() => {
+      expect(ProjectService.updateProject).toHaveBeenCalledWith(
+        "1",
+        expect.objectContaining({ authorName: "Anonymous" })
+      );
+    });
+  });
+  test("save button is disabled when no changes", async () => {
+    const spyUpdate = vi.spyOn(ProjectService, "updateProject");
+
+    renderWithRouter("1");
+    const saveButton = await screen.findByText(/Update Project/i);
+    let container = saveButton.parentElement;
+    while (
+      container &&
+      !container.classList.contains("opacity-40") &&
+      container !== document.body
+    ) {
+      container = container.parentElement;
+    }
+    expect(container).toHaveClass("opacity-40");
+
+    // Versuche, ob der Button klickbar ist (keine pointer-events-none Klasse)
+    const isClickable = !container?.classList.contains("pointer-events-none");
+    if (isClickable) {
+      saveButton.click();
+    }
+
+    // Es sollte kein Update-Aufruf stattfinden
+    expect(spyUpdate).not.toHaveBeenCalled();
+
+    spyUpdate.mockRestore();
+  });
+
+  test("does not add empty tag", async () => {
+    const user = userEvent.setup();
+    renderWithRouter("1");
+
+    // Tags zählen vor Add-Versuch anhand spezifischer Klasse im Container (z.B. bg-purple-200)
+    const tagsBefore = screen.queryAllByText((content, element) => {
+      return (
+        !!element &&
+        element.classList &&
+        element.classList.contains("text-purple-800")
+      );
+    });
+
+    const input = await screen.findByPlaceholderText("Add Tag");
+    await user.clear(input);
+
+    const addBtn = screen.getByText("Add");
+    await user.click(addBtn);
+
+    // Tags zählen nach Add-Versuch
+    const tagsAfter = screen.queryAllByText((content, element) => {
+      return (
+        !!element &&
+        element.classList &&
+        element.classList.contains("text-purple-800")
+      );
+    });
+
+    expect(tagsAfter.length).toBe(tagsBefore.length);
+  });
+});

--- a/src/components/ContributionCard/ContributionCard.tsx
+++ b/src/components/ContributionCard/ContributionCard.tsx
@@ -42,7 +42,10 @@ const ContributionCard: React.FC = () => {
     }
   }, [projectId, reloadTrigger]);
 
-  const updateProjectField = (field: keyof Project, value: any) => {
+  const updateProjectField = <K extends keyof Project>(
+    field: K,
+    value: Project[K],
+  ) => {
     setProject((prev) => (prev ? { ...prev, [field]: value } : prev));
   };
 
@@ -57,7 +60,7 @@ const ContributionCard: React.FC = () => {
     if (project) {
       updateProjectField(
         "tags",
-        project.tags?.filter((tag) => tag !== tagToRemove) || []
+        project.tags?.filter((tag) => tag !== tagToRemove) || [],
       );
     }
   };

--- a/src/components/ContributionCard/ContributionCard.tsx
+++ b/src/components/ContributionCard/ContributionCard.tsx
@@ -1,0 +1,395 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { ProjectService } from "../../utils/ProjectService";
+import { Project } from "../../utils/types";
+import { motion } from "framer-motion";
+import { UploadCloud } from "lucide-react";
+
+const ContributionCard: React.FC = () => {
+  const { projectId } = useParams<{ projectId: string }>();
+  const [project, setProject] = useState<Project | null>(null);
+  const [newTag, setNewTag] = useState<string>("");
+  const [initialIsPublic, setInitialIsPublic] = useState<boolean | null>(null);
+  const [originalProject, setOriginalProject] = useState<Project | null>(null);
+  const [reloadTrigger, setReloadTrigger] = useState(0);
+  const [isAnonymous, setIsAnonymous] = useState(false);
+
+  useEffect(() => {
+    if (projectId) {
+      ProjectService.getProjectById(projectId)
+        .then((project: Project) => {
+          if (
+            Array.isArray(project.projectStructure) ||
+            typeof project.projectStructure === "object"
+          ) {
+            setProject({
+              ...project,
+              isPublic: project.isPublic ?? false,
+              titleCommunityPage: project.titleCommunityPage ?? project.name,
+              category: project.category ?? "",
+              tags: project.tags ?? [],
+              typeOfDocument: project.typeOfDocument ?? "",
+              username: project.username ?? "Anonymous",
+            });
+            setIsAnonymous(project.authorName === "Anonymous");
+            setInitialIsPublic(project.isPublic ?? false);
+            setOriginalProject(project);
+          } else {
+            console.error("Project structure is not valid!");
+          }
+        })
+        .catch((error) => console.error("Error fetching project:", error));
+    }
+  }, [projectId, reloadTrigger]);
+
+  const updateProjectField = (field: keyof Project, value: any) => {
+    setProject((prev) => (prev ? { ...prev, [field]: value } : prev));
+  };
+
+  const addTag = () => {
+    if (newTag.trim() !== "" && project) {
+      updateProjectField("tags", [...(project.tags || []), newTag.trim()]);
+      setNewTag("");
+    }
+  };
+
+  const removeTag = (tagToRemove: string) => {
+    if (project) {
+      updateProjectField(
+        "tags",
+        project.tags?.filter((tag) => tag !== tagToRemove) || []
+      );
+    }
+  };
+  const hasChanges = () => {
+    if (!project || !originalProject) return false;
+
+    return (
+      project.isPublic !== originalProject.isPublic ||
+      project.titleCommunityPage !== originalProject.titleCommunityPage ||
+      project.category !== originalProject.category ||
+      project.typeOfDocument !== originalProject.typeOfDocument ||
+      project.authorName !== originalProject.authorName ||
+      JSON.stringify(project.tags) !== JSON.stringify(originalProject.tags) ||
+      isAnonymous !== (originalProject.authorName === "Anonymous") // 👈 Änderung hier
+    );
+  };
+
+  const isFormValid = () => {
+    if (!project) return false;
+
+    // wenn das Projekt privat ist, gibt es keine Pflichtfelder
+    if (!project.isPublic) return true;
+
+    const hasCategory = project.category && project.category !== "";
+    const hasDocType = project.typeOfDocument && project.typeOfDocument !== "";
+    const hasTitle =
+      project.titleCommunityPage && project.titleCommunityPage.trim() !== "";
+    const hasTags = project.tags && project.tags.length > 0;
+
+    return hasCategory && hasDocType && hasTitle && hasTags;
+  };
+
+  const getButtonText = () => {
+    if (initialIsPublic === false && project?.isPublic === false) return null;
+    if (initialIsPublic === false && project?.isPublic === true)
+      return "Publish Project";
+    if (initialIsPublic === true && project?.isPublic) return "Update Project";
+    if (initialIsPublic === true && !project?.isPublic) return "Hide Project";
+    return null;
+  };
+
+  const getButtonStyles = () => {
+    const text = getButtonText();
+    if (text === "Hide Project") {
+      return {
+        gradient: "bg-gradient-to-r from-red-500 via-orange-400 to-yellow-500",
+        shadow: "shadow-inner/30 dark:shadow-inner shadow-orange-800/40",
+        textColor: "text-[#cb8a07] dark:text-[#eeae38]",
+        hoverText: "group-hover:text-[#815c11] dark:group-hover:text-[#faebcf]",
+        iconColor: "stroke-[#cb8a07] dark:stroke-[#eeae38]",
+      };
+    } else {
+      return {
+        gradient: "bg-gradient-to-r from-teal-400 via-cyan-400 to-blue-500",
+        shadow: "shadow-inner/30 dark:shadow-inner shadow-cyan-800/40",
+        textColor: "text-[#14ab94] dark:text-[#00FFD1]",
+        hoverText: "group-hover:text-[#0d6e60] dark:group-hover:text-[#d7faf3]",
+        iconColor: "stroke-[#14ab94] dark:stroke-[#00FFD1]",
+      };
+    }
+  };
+
+  const saveProject = async () => {
+    if (!projectId || !project) return;
+
+    const projectData = {
+      name: project.name || "Untitled Project",
+      authorName: isAnonymous ? "Anonymous" : project.username || "Anonymous",
+      isPublic: project.isPublic,
+      titleCommunityPage: project.titleCommunityPage,
+      category: project.category,
+      typeOfDocument: project.typeOfDocument,
+      tags: project.tags || [],
+      projectStructure: project.projectStructure || [],
+    };
+
+    try {
+      await ProjectService.updateProject(projectId, projectData);
+      console.log("✅ Project updated successfully.");
+      setReloadTrigger((prev) => prev + 1);
+    } catch (error) {
+      console.error("❌ Failed to update project:", error);
+    }
+  };
+
+  if (!project) {
+    return (
+      <div className="flex items-center justify-center h-full text-gray-700 dark:text-gray-300">
+        Loading project...
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative flex flex-col h-full p-10 rounded-3xl bg-[#e9e5f8] dark:bg-[#1e1538] text-[#261e3b] dark:text-white shadow-[0_0_40px_rgba(14,165,233,0.2)]">
+      <h2 className="text-3xl font-bold inline-block tracking-wide mb-6">
+        Contribution
+        <div className="h-1 mt-1.5 w-[166px] bg-gradient-to-r from-purple-500 via-pink-400 to-yellow-300 rounded-full" />
+      </h2>
+
+      {/* Public / Private Toggle */}
+      <label className="flex items-center gap-4 mb-8">
+        <span className="font-semibold">Visibility:</span>
+        <div
+          className={`w-16 h-8 flex items-center rounded-full p-1 cursor-pointer transition-colors duration-300 ${
+            project.isPublic
+              ? "bg-gradient-to-r from-teal-400 via-cyan-400 to-blue-500"
+              : "bg-[#c5bedc] dark:bg-[#3a2f57]"
+          }`}
+          onClick={() => updateProjectField("isPublic", !project.isPublic)}
+        >
+          <div
+            className={`bg-white dark:bg-gray-200 w-6 h-6 rounded-full shadow-md transform transition-transform duration-300 ${
+              project.isPublic ? "translate-x-8" : "translate-x-0"
+            }`}
+          ></div>
+        </div>
+        <span className="text-sm font-medium">
+          {project.isPublic ? "Public" : "Private"}
+        </span>
+      </label>
+
+      {project.isPublic && (
+        <>
+          {/* Community Page Title */}
+          <input
+            type="text"
+            value={project.titleCommunityPage || ""}
+            onChange={(e) =>
+              updateProjectField("titleCommunityPage", e.target.value)
+            }
+            placeholder="Community Page Title"
+            className="w-full px-4 py-3 mb-6 rounded-md bg-[#dad5ee] text-[#261e3b] dark:bg-[#2a1e44] dark:text-white placeholder-gray-600 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-teal-400"
+          />
+
+          {/* Category */}
+          <select
+            value={project.category || ""}
+            onChange={(e) => updateProjectField("category", e.target.value)}
+            className="w-full px-4 py-3 mb-6 rounded-md bg-[#dad5ee] text-[#261e3b] 
+    dark:bg-[#2a1e44] dark:text-white focus:outline-none focus:ring-2 
+    focus:ring-teal-400"
+          >
+            <option value="">-- Select Category --</option>
+            <option value="Computer Science">Computer Science</option>
+            <option value="Biology">Biology</option>
+            <option value="Economy">Economy</option>
+            <option value="Physics">Physics</option>
+            <option value="Mathematics">Mathematics</option>
+            <option value="Chemistry">Chemistry</option>
+            <option value="Psychology">Psychology</option>
+            <option value="Sociology">Sociology</option>
+            <option value="Political Science">Political Science</option>
+            <option value="History">History</option>
+            <option value="Philosophy">Philosophy</option>
+            <option value="Literature">Literature</option>
+            <option value="Engineering">Engineering</option>
+            <option value="Environmental Science">Environmental Science</option>
+            <option value="Medicine">Medicine</option>
+            <option value="Nursing">Nursing</option>
+            <option value="Law">Law</option>
+            <option value="Linguistics">Linguistics</option>
+            <option value="Anthropology">Anthropology</option>
+            <option value="Art History">Art History</option>
+            <option value="Education">Education</option>
+            <option value="Business Administration">
+              Business Administration
+            </option>
+            <option value="Finance">Finance</option>
+            <option value="Marketing">Marketing</option>
+            <option value="Architecture">Architecture</option>
+            <option value="Geography">Geography</option>
+            <option value="Astronomy">Astronomy</option>
+            <option value="Neuroscience">Neuroscience</option>
+            <option value="Information Technology">
+              Information Technology
+            </option>
+            <option value="Pharmacy">Pharmacy</option>
+            <option value="Social Work">Social Work</option>
+            <option value="Communication Studies">Communication Studies</option>
+            <option value="Journalism">Journalism</option>
+            <option value="Statistics">Statistics</option>
+            <option value="Data Science">Data Science</option>
+            <option value="Ethics">Ethics</option>
+            <option value="Cognitive Science">Cognitive Science</option>
+            <option value="Public Health">Public Health</option>
+            <option value="International Relations">
+              International Relations
+            </option>
+            <option value="Theology">Theology</option>
+            <option value="Musicology">Musicology</option>
+            <option value="Performing Arts">Performing Arts</option>
+            <option value="Film Studies">Film Studies</option>
+            <option value="Nutrition Science">Nutrition Science</option>
+            <option value="Sports Science">Sports Science</option>
+            <option value="Other">Other</option>
+          </select>
+
+          {/* Tags */}
+          <div className="flex gap-2 mb-4">
+            <input
+              type="text"
+              value={newTag}
+              onChange={(e) => setNewTag(e.target.value)}
+              placeholder="Add Tag"
+              className="flex-1 px-4 py-3 rounded-md bg-[#dad5ee] text-[#261e3b] 
+      dark:bg-[#2a1e44] dark:text-white placeholder-gray-600 
+      dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-teal-400"
+            />
+            <button
+              onClick={addTag}
+              className="relative px-5 py-2 rounded-md font-medium 
+    border border-teal-400 dark:border-cyan-400 
+    text-teal-500 dark:text-cyan-300 
+    bg-transparent transition-all duration-300 
+    group hover:scale-105"
+            >
+              <span
+                className="transition-colors duration-300 group-hover:text-teal-700 dark:group-hover:text-cyan-200
+      relative before:absolute before:-bottom-1 before:left-0 before:w-0 before:h-[2px] 
+      before:bg-teal-400 dark:before:bg-cyan-400 
+      group-hover:before:w-full before:transition-all before:duration-300"
+              >
+                Add
+              </span>
+            </button>
+          </div>
+
+          <div className="flex flex-wrap gap-2 mb-6">
+            {project.tags?.map((tag, idx) => (
+              <div
+                key={idx}
+                className="flex items-center gap-2 px-3 py-1.5 
+        bg-purple-200 dark:bg-purple-700/40 
+        text-purple-800 dark:text-purple-200 
+        rounded-full text-sm font-medium shadow-sm"
+              >
+                <span>{tag}</span>
+                <button
+                  onClick={() => removeTag(tag)}
+                  className="text-purple-600 dark:text-purple-300 hover:text-red-500 transition-colors duration-200 font-bold"
+                >
+                  ✕
+                </button>
+              </div>
+            ))}
+          </div>
+
+          {/* Type of Document */}
+          <select
+            value={project.typeOfDocument || ""}
+            onChange={(e) =>
+              updateProjectField("typeOfDocument", e.target.value)
+            }
+            className="w-full px-4 py-3 mb-8 rounded-md bg-[#dad5ee] text-[#261e3b] 
+    dark:bg-[#2a1e44] dark:text-white focus:outline-none focus:ring-2 
+    focus:ring-teal-400"
+          >
+            <option value="">-- Select Work Type --</option>
+            <option value="Bachelor Thesis">Bachelor Thesis</option>
+            <option value="Master Thesis">Master Thesis</option>
+            <option value="Doctoral Dissertation">Doctoral Dissertation</option>
+            <option value="PTB">PTB</option>
+            <option value="Research Paper">Research Paper</option>
+            <option value="Term Paper">Term Paper</option>
+            <option value="Seminar Paper">Seminar Paper</option>
+            <option value="Essay">Essay</option>
+            <option value="Project Report">Project Report</option>
+            <option value="Capstone Project">Capstone Project</option>
+            <option value="Case Study">Case Study</option>
+            <option value="Thesis Proposal">Thesis Proposal</option>
+            <option value="Literature Review">Literature Review</option>
+            <option value="Technical Report">Technical Report</option>
+            <option value="White Paper">White Paper</option>
+            <option value="Dissertation Proposal">Dissertation Proposal</option>
+            <option value="Academic Article">Academic Article</option>
+            <option value="Conference Paper">Conference Paper</option>
+            <option value="Review Paper">Review Paper</option>
+            <option value="Book Chapter">Book Chapter</option>
+            <option value="Policy Paper">Policy Paper</option>
+            <option value="Other">Other</option>
+          </select>
+
+          {/* Anonymous Checkbox */}
+          <div className="flex items-center gap-2 mb-4">
+            <input
+              type="checkbox"
+              id="anonymous"
+              checked={isAnonymous}
+              onChange={(e) => setIsAnonymous(e.target.checked)}
+              className="w-4 h-4"
+            />
+            <label htmlFor="anonymous" className="text-sm font-medium">
+              Post as Anonymous
+            </label>
+          </div>
+        </>
+      )}
+      {/* Save / Share Button */}
+      {getButtonText() && (
+        <motion.div
+          onClick={saveProject}
+          whileHover={{
+            scale: hasChanges() && isFormValid() ? 1.05 : 1,
+            boxShadow:
+              hasChanges() && isFormValid()
+                ? getButtonText() === "Hide Project"
+                  ? "0 0 20px rgba(251,146,60,0.5)"
+                  : "0 0 20px rgba(0,255,163,0.5)"
+                : "none",
+          }}
+          className={`cursor-pointer p-[2px] rounded-xl ${getButtonStyles().gradient} w-[300px] mx-auto mt-4 ${
+            (!hasChanges() || !isFormValid()) &&
+            getButtonText() !== "Publish Project"
+              ? "opacity-40 pointer-events-none"
+              : ""
+          }`}
+        >
+          <div
+            className={`group flex items-center justify-center bg-[#e9e5f8] dark:bg-[#1e1538] dark:bg-opacity-90 backdrop-blur-md p-4 rounded-xl ${getButtonStyles().shadow} border border-[#dad1f5] dark:border-[#32265b]`}
+          >
+            <UploadCloud className={`w-8 h-8 ${getButtonStyles().iconColor}`} />
+            <span
+              className={`ml-4 text-xl font-semibold transition-colors duration-300 ${getButtonStyles().textColor} ${getButtonStyles().hoverText} relative before:absolute before:-bottom-1 before:left-0 before:w-0 before:h-[2px] before:bg-[#00FFD1] group-hover:before:w-full before:transition-all before:duration-300`}
+            >
+              {getButtonText()}
+            </span>
+          </div>
+        </motion.div>
+      )}
+    </div>
+  );
+};
+
+export default ContributionCard;

--- a/src/components/FileContentCard/FileContentCardRead.test.tsx
+++ b/src/components/FileContentCard/FileContentCardRead.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi, describe, it, beforeEach, expect } from "vitest";
+
+// --- mock icons ---
+vi.mock("../../utils/icons", () => ({
+  getIcon: () => <div data-testid="icon" />,
+}));
+
+import FileContentCardRead from "./FileContentCardRead";
+
+describe("FileContentCardRead", () => {
+  const baseNode = {
+    id: "n1",
+    name: "MyFile",
+    category: "docs",
+    content: "Hello world",
+    icon: "icon-file",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders name, icon and initial content", () => {
+    render(<FileContentCardRead node={baseNode as any} />);
+
+    expect(screen.getByText(baseNode.name)).toBeInTheDocument();
+    expect(screen.getByTestId("icon")).toBeInTheDocument();
+
+    const ta = screen.getByPlaceholderText(
+      /Write your content here/i
+    ) as HTMLTextAreaElement;
+    expect(ta.value).toBe("Hello world");
+  });
+
+  it("falls back to '...' if node.content is missing", () => {
+    const node = { ...baseNode, content: undefined };
+    render(<FileContentCardRead node={node as any} />);
+    const ta = screen.getByPlaceholderText(
+      /Write your content here/i
+    ) as HTMLTextAreaElement;
+    expect(ta.value).toBe("...");
+  });
+
+  it("typing updates the textarea value", async () => {
+    const user = userEvent.setup();
+    render(<FileContentCardRead node={baseNode as any} />);
+
+    const ta = screen.getByPlaceholderText(
+      /Write your content here/i
+    ) as HTMLTextAreaElement;
+    await user.clear(ta);
+    await user.type(ta, "New content here");
+    expect(ta.value).toBe("New content here");
+  });
+
+  it("updates content when new node prop arrives", async () => {
+    const { rerender } = render(<FileContentCardRead node={baseNode as any} />);
+    const ta = screen.getByPlaceholderText(
+      /Write your content here/i
+    ) as HTMLTextAreaElement;
+
+    expect(ta.value).toBe("Hello world");
+
+    const newNode = { ...baseNode, content: "Fresh data" };
+    rerender(<FileContentCardRead node={newNode as any} />);
+
+    await waitFor(() => {
+      expect(ta.value).toBe("Fresh data");
+    });
+  });
+
+  it("syncScroll copies textarea scrollTop to overlay", () => {
+    render(<FileContentCardRead node={baseNode as any} />);
+    const ta = screen.getByPlaceholderText(
+      /Write your content here/i
+    ) as HTMLTextAreaElement;
+
+    // Finde overlayRef -> parent von Textarea
+    const container = ta.closest("div.relative.flex-1") as HTMLElement;
+    expect(container).toBeInTheDocument();
+
+    // Scroll simulieren
+    ta.scrollTop = 42;
+    ta.dispatchEvent(new Event("scroll"));
+
+    // OverlayRef sollte denselben scrollTop haben
+    // -> Zugriff über sibling im gleichen Container
+    const overlayDiv = container.querySelector("div");
+    if (overlayDiv) {
+      expect(overlayDiv.scrollTop).toBe(ta.scrollTop);
+    }
+  });
+});

--- a/src/components/FileContentCard/FileContentCardRead.test.tsx
+++ b/src/components/FileContentCard/FileContentCardRead.test.tsx
@@ -29,7 +29,7 @@ describe("FileContentCardRead", () => {
     expect(screen.getByTestId("icon")).toBeInTheDocument();
 
     const ta = screen.getByPlaceholderText(
-      /Write your content here/i
+      /Write your content here/i,
     ) as HTMLTextAreaElement;
     expect(ta.value).toBe("Hello world");
   });
@@ -38,7 +38,7 @@ describe("FileContentCardRead", () => {
     const node = { ...baseNode, content: undefined };
     render(<FileContentCardRead node={node as any} />);
     const ta = screen.getByPlaceholderText(
-      /Write your content here/i
+      /Write your content here/i,
     ) as HTMLTextAreaElement;
     expect(ta.value).toBe("...");
   });
@@ -48,7 +48,7 @@ describe("FileContentCardRead", () => {
     render(<FileContentCardRead node={baseNode as any} />);
 
     const ta = screen.getByPlaceholderText(
-      /Write your content here/i
+      /Write your content here/i,
     ) as HTMLTextAreaElement;
     await user.clear(ta);
     await user.type(ta, "New content here");
@@ -58,7 +58,7 @@ describe("FileContentCardRead", () => {
   it("updates content when new node prop arrives", async () => {
     const { rerender } = render(<FileContentCardRead node={baseNode as any} />);
     const ta = screen.getByPlaceholderText(
-      /Write your content here/i
+      /Write your content here/i,
     ) as HTMLTextAreaElement;
 
     expect(ta.value).toBe("Hello world");
@@ -74,7 +74,7 @@ describe("FileContentCardRead", () => {
   it("syncScroll copies textarea scrollTop to overlay", () => {
     render(<FileContentCardRead node={baseNode as any} />);
     const ta = screen.getByPlaceholderText(
-      /Write your content here/i
+      /Write your content here/i,
     ) as HTMLTextAreaElement;
 
     // Finde overlayRef -> parent von Textarea

--- a/src/components/FileContentCard/FileContentCardRead.tsx
+++ b/src/components/FileContentCard/FileContentCardRead.tsx
@@ -1,0 +1,62 @@
+import { useState, useRef, useEffect } from "react";
+import { Node } from "../../utils/types";
+import { getIcon } from "../../utils/icons";
+
+export interface FileContentCardProps {
+  node: Node;
+  onDirtyChange?: (dirty: boolean) => void;
+  onSave?: () => void;
+}
+
+function FileContentCardRead({ node }: FileContentCardProps) {
+  const [fileContent, setFileContent] = useState<string>(node.content || "...");
+
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  // 🔑 Synchronisiere State mit neuen Props
+  useEffect(() => {
+    setFileContent(node.content || "...");
+  }, [node]);
+
+  const syncScroll = () => {
+    if (textareaRef.current && overlayRef.current) {
+      overlayRef.current.scrollTop = textareaRef.current.scrollTop;
+    }
+  };
+
+  return (
+    <div className="relative flex flex-col h-full p-6 rounded-3xl bg-[#e9e5f8] dark:bg-[#1e1538]">
+      <div className="absolute mt-0.5 ml-4">
+        <div className="rounded-lg bg-gradient-to-tr from-purple-500 via-pink-400 to-yellow-300 p-[2px]">
+          <div className="rounded-lg bg-[#e1dcf8] dark:bg-[#2f214d] p-2">
+            {getIcon(node, "w-8 h-8", node.icon)}
+          </div>
+        </div>
+      </div>
+      <div className="relative mb-6 px-21">
+        <h2 className="text-3xl font-bold inline-block tracking-wide">
+          <span className="text-[#261e3b] dark:text-[#ffffff]">
+            {node.name}{" "}
+          </span>
+          <span className="block h-1 w-full mt-1.5 bg-gradient-to-r from-purple-500 via-pink-400 to-yellow-300 rounded-full" />
+        </h2>
+      </div>
+
+      <div className="relative flex-1 mt-1 rounded-xl overflow-hidden border-2 border-[#afa4e0] dark:border-[#35285f] focus-within:ring-2 focus-within:ring-purple-400 dark:focus-within:ring-purple-700">
+        <textarea
+          ref={textareaRef}
+          value={fileContent}
+          onChange={(e) => setFileContent(e.target.value)}
+          onScroll={syncScroll}
+          placeholder="Write your content here..."
+          spellCheck={false}
+          className="relative z-20 w-full h-full p-4 bg-transparent text-[#261e3b] dark:text-[#ffffff] focus:outline-none placeholder:text-[#888] dark:placeholder:text-[#777] resize-none transition whitespace-pre-wrap"
+          style={{ fontSize: "1rem", lineHeight: "1.5" }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default FileContentCardRead;

--- a/src/components/Folder/FolderRead.test.tsx
+++ b/src/components/Folder/FolderRead.test.tsx
@@ -41,13 +41,13 @@ const baseNode = (overrides?: Partial<Node>): Node => ({
 
 const setup = (
   node: Node,
-  props?: Partial<React.ComponentProps<typeof FolderRead>>
+  props?: Partial<React.ComponentProps<typeof FolderRead>>,
 ) => {
   const onNodeClick = vi.fn();
   const utils = render(
     <ul>
       <FolderRead node={node} onNodeClick={onNodeClick} {...props} />
-    </ul>
+    </ul>,
   );
   return { ...utils, onNodeClick };
 };
@@ -64,7 +64,7 @@ describe("FolderRead", () => {
     expect(screen.getByText("Chapter 1")).toBeInTheDocument();
     expect(screen.getByTestId("node-icon")).toHaveAttribute(
       "data-icon",
-      "text"
+      "text",
     );
   });
 
@@ -83,7 +83,7 @@ describe("FolderRead", () => {
     // selected version renders with gradient underline span
     expect(screen.getByText("Selected")).toBeInTheDocument();
     expect(screen.getByText("Selected").closest("span")).toHaveClass(
-      "relative"
+      "relative",
     );
   });
 

--- a/src/components/Folder/FolderRead.test.tsx
+++ b/src/components/Folder/FolderRead.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import React from "react";
+
+// --- mocks ---
+vi.mock("framer-motion", async () => {
+  const ReactPkg = await import("react");
+  const passthrough = (tag: any) => (props: any) =>
+    ReactPkg.createElement(tag, props, props?.children);
+  return {
+    motion: {
+      div: passthrough("div"),
+      span: passthrough("span"),
+    },
+  };
+});
+
+vi.mock("../../utils/icons", async () => {
+  const ReactPkg = await import("react");
+  return {
+    getIcon: (_node: any, _size: string, icon?: string) =>
+      ReactPkg.createElement("svg", {
+        "data-testid": "node-icon",
+        "data-icon": icon || "text",
+      }),
+  };
+});
+
+// --- import after mocks ---
+import FolderRead from "./FolderRead";
+import type { Node } from "../../utils/types";
+
+const baseNode = (overrides?: Partial<Node>): Node => ({
+  id: "n1",
+  name: "Chapter 1",
+  icon: "text",
+  nodes: [],
+  ...overrides,
+});
+
+const setup = (
+  node: Node,
+  props?: Partial<React.ComponentProps<typeof FolderRead>>
+) => {
+  const onNodeClick = vi.fn();
+  const utils = render(
+    <ul>
+      <FolderRead node={node} onNodeClick={onNodeClick} {...props} />
+    </ul>
+  );
+  return { ...utils, onNodeClick };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("FolderRead", () => {
+  it("renders node name and icon", () => {
+    const node = baseNode();
+    setup(node);
+
+    expect(screen.getByText("Chapter 1")).toBeInTheDocument();
+    expect(screen.getByTestId("node-icon")).toHaveAttribute(
+      "data-icon",
+      "text"
+    );
+  });
+
+  it("calls onNodeClick when name is clicked", async () => {
+    const node = baseNode();
+    const { onNodeClick } = setup(node);
+
+    await userEvent.click(screen.getByText("Chapter 1"));
+    expect(onNodeClick).toHaveBeenCalledWith(node);
+  });
+
+  it("applies selected styles when selectedNodeId matches", () => {
+    const node = baseNode({ id: "sel-1", name: "Selected" });
+    setup(node, { selectedNodeId: "sel-1" });
+
+    // selected version renders with gradient underline span
+    expect(screen.getByText("Selected")).toBeInTheDocument();
+    expect(screen.getByText("Selected").closest("span")).toHaveClass(
+      "relative"
+    );
+  });
+
+  it("renders children recursively", () => {
+    const child: Node = { id: "c1", name: "Child", nodes: [] };
+    const node = baseNode({ nodes: [child] });
+
+    setup(node);
+    expect(screen.getByText("Child")).toBeInTheDocument();
+  });
+
+  it("applies hidden styles when isVisible=false", () => {
+    const node = baseNode();
+    setup(node, { isVisible: false });
+
+    const li = screen.getByText("Chapter 1").closest("li");
+    expect(li).toHaveClass("opacity-0");
+    expect(li).toHaveClass("max-h-0");
+  });
+});

--- a/src/components/Folder/FolderRead.tsx
+++ b/src/components/Folder/FolderRead.tsx
@@ -1,0 +1,105 @@
+import { useRef } from "react";
+import { Node } from "../../utils/types";
+import { getIcon } from "../../utils/icons";
+import { motion } from "framer-motion";
+
+interface FolderProps {
+  node: Node;
+  onNodeClick: (node: Node) => void;
+  isVisible?: boolean;
+  selectedNodeId?: string;
+}
+
+function FolderRead({
+  node,
+  onNodeClick,
+  isVisible = true,
+  selectedNodeId = "",
+}: FolderProps) {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const isSelected = selectedNodeId === node.id;
+
+  const hasChildren = Array.isArray(node.nodes) && node.nodes.length > 0;
+
+  return (
+    <li
+      className={`my-1 transition-opacity duration-300 ${
+        isVisible ? "opacity-100" : "opacity-0"
+      } ${isVisible ? "max-h-screen" : "max-h-0 overflow-hidden"} `}
+    >
+      <div className="flex items-center gap-2">
+        {/* Icon */}
+        <motion.div ref={wrapperRef}>
+          <div
+            className={`flex items-center justify-center w-8 h-8 rounded-full bg-[#e9e5f8] dark:bg-[#1e1538]`}
+          >
+            {getIcon(node, "w-5 h-5", node.icon)}
+          </div>
+        </motion.div>
+
+        {/* Name */}
+        <motion.span
+          whileHover={{ scale: 1.025, transition: { duration: 0.2 } }}
+          whileTap={{ scale: 0.95 }}
+          className={`flex-1 min-w-0 whitespace-normal break-words cursor-pointer px-3 py-2 rounded-lg
+            ${
+              isSelected
+                ? `text-[#362466] dark:text-white bg-transparent border border-transparent transition-colors duration-0`
+                : `hover:bg-[#eae5fa] dark:hover:bg-[#312350] hover:shadow-[0_2_8px_rgba(120,69,239,0.3)] dark:hover:shadow-[0_2_8px_rgba(120,69,239,0.2)] border border-transparent transition-colors duration-200`
+            }`}
+          onClick={() => onNodeClick(node)}
+        >
+          {isSelected ? (
+            <span
+              className="relative z-10 block rounded-lg px-3 py-2 border-[2px] border-transparent"
+              style={{
+                borderImage:
+                  "linear-gradient(to left, #facc15, #ec4899, #8b5cf6) 1",
+              }}
+            >
+              <span className="relative">
+                {node.name}
+                <span className="absolute -bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-purple-500 via-pink-400 to-yellow-300 rounded-full" />
+              </span>
+            </span>
+          ) : (
+            node.name
+          )}
+        </motion.span>
+      </div>
+
+      {/* Children */}
+      {hasChildren && (
+        <div
+          className={`${
+            node.id !== "1"
+              ? "max-h-[700px] overflow-y-auto pr-2 max-w-full overflow-x-auto"
+              : ""
+          }`}
+        >
+          <ul
+            className={`pl-4 space-y-1 ${
+              node.id !== "1"
+                ? "border-l border-[#baaaed]/30 dark:border-[#32265b]/80 ml-0.5"
+                : ""
+            }`}
+          >
+            <div className={`${node.id !== "1" ? "min-w-fit" : ""}`}>
+              {node.nodes!.map((childNode) => (
+                <FolderRead
+                  key={childNode.id}
+                  node={childNode}
+                  onNodeClick={onNodeClick}
+                  isVisible={isVisible}
+                  selectedNodeId={selectedNodeId}
+                />
+              ))}
+            </div>
+          </ul>
+        </div>
+      )}
+    </li>
+  );
+}
+
+export default FolderRead;

--- a/src/components/FullDocumentCard/FullDocumentCard.tsx
+++ b/src/components/FullDocumentCard/FullDocumentCard.tsx
@@ -61,10 +61,12 @@ const FullDocumentCard = () => {
     const fetchStructure = async () => {
       try {
         const data = await ProjectService.getProjectById(projectId); // Use the projectId from URL
-        if (data && data.projectStructure) {
-          setStructure(data.projectStructure);
+
+        if (data && Array.isArray(data.projectStructure)) {
+          setStructure(data.projectStructure as StructureNode[]);
         } else {
-          setError("Project structure is empty or unavailable.”");
+          setError("Project structure is empty or unavailable.");
+          setStructure([]); // Fallback, damit der State korrekt bleibt
         }
       } catch {
         setError("Error loading the project structure.");

--- a/src/pages/EditPage/EditPage.tsx
+++ b/src/pages/EditPage/EditPage.tsx
@@ -15,6 +15,7 @@ import FullDocumentCard from "../../components/FullDocumentCard/FullDocumentCard
 import { ProjectService } from "../../utils/ProjectService";
 import { useParams } from "react-router-dom";
 import { motion } from "framer-motion";
+import ContributionCard from "../../components/ContributionCard/ContributionCard";
 
 const EditPage = () => {
   const { projectId } = useParams<{ projectId: string }>();
@@ -209,7 +210,7 @@ const EditPage = () => {
   const addChapter = (parentId: string | null, newNode: Node) => {
     const recursiveUpdate = (
       nodes: Node[],
-      parentId: string | null,
+      parentId: string | null
     ): Node[] => {
       return nodes.map((node) => {
         if (node.id === parentId) {
@@ -275,7 +276,7 @@ const EditPage = () => {
       setSelectedNode((prev) =>
         prev
           ? { ...prev, name: updatedNode.name, icon: updatedNode.icon }
-          : prev,
+          : prev
       );
     }
 
@@ -296,7 +297,7 @@ const EditPage = () => {
 
   const handleMoveNode = (
     draggedNodeId: string,
-    targetNodeId: string,
+    targetNodeId: string
     //asSibling: boolean = false
   ) => {
     const newNodes = [...nodes];
@@ -417,6 +418,8 @@ const EditPage = () => {
                     <AIProtocolCard />
                   ) : activeView === "fullDocument" ? (
                     <FullDocumentCard />
+                  ) : activeView === "contribution" ? (
+                    <ContributionCard />
                   ) : (
                     <div className="flex h-full items-center justify-center">
                       <p className="text-xl text-[#261e3b] dark:text-[#aaa6c3] leading-relaxed">

--- a/src/pages/EditPage/EditPage.tsx
+++ b/src/pages/EditPage/EditPage.tsx
@@ -210,7 +210,7 @@ const EditPage = () => {
   const addChapter = (parentId: string | null, newNode: Node) => {
     const recursiveUpdate = (
       nodes: Node[],
-      parentId: string | null
+      parentId: string | null,
     ): Node[] => {
       return nodes.map((node) => {
         if (node.id === parentId) {
@@ -276,7 +276,7 @@ const EditPage = () => {
       setSelectedNode((prev) =>
         prev
           ? { ...prev, name: updatedNode.name, icon: updatedNode.icon }
-          : prev
+          : prev,
       );
     }
 
@@ -297,7 +297,7 @@ const EditPage = () => {
 
   const handleMoveNode = (
     draggedNodeId: string,
-    targetNodeId: string
+    targetNodeId: string,
     //asSibling: boolean = false
   ) => {
     const newNodes = [...nodes];

--- a/src/pages/ProjectOverview/ProjectOverview.tsx
+++ b/src/pages/ProjectOverview/ProjectOverview.tsx
@@ -96,11 +96,15 @@ const ProjectOverview = () => {
   // Methode zum Aktualisieren des Projekts
   const updateProjectName = async (project: Project) => {
     try {
-      // Kopiere die projectStructure, um den Namen des ersten Nodes zu aktualisieren
-      const updatedProjectStructure = [...project.projectStructure];
+      // Kopiere die projectStructure, falls vorhanden
+      const updatedProjectStructure = Array.isArray(project.projectStructure)
+        ? [...project.projectStructure]
+        : [];
+
       const firstNode = updatedProjectStructure.find(
         (structure) => structure.id === "1",
       );
+
       if (firstNode) {
         firstNode.name = editedName; // Setze den neuen Projektnamen
       }
@@ -110,6 +114,7 @@ const ProjectOverview = () => {
         name: editedName,
         username: user?.username || "",
         projectStructure: updatedProjectStructure, // Sende die aktualisierte Struktur
+        isPublic: project.isPublic, // wichtig, falls dein Typ 'Project' das verlangt
       });
 
       // Projekte im Zustand aktualisieren

--- a/src/pages/ReadingPage/ReadingPage.test.tsx
+++ b/src/pages/ReadingPage/ReadingPage.test.tsx
@@ -1,0 +1,182 @@
+import { vi } from "vitest";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { render } from "../../../test/renderWithProviders";
+import ReadingPage from "./ReadingPage";
+
+// Mock CSS
+vi.mock("../../App/App.css", () => ({}));
+
+// Mock child components
+vi.mock("../../components/Folder/FolderRead", () => ({
+  __esModule: true,
+  default: ({ node, onNodeClick, selectedNodeId }: any) => (
+    <li data-testid={`folder-${node.id}`}>
+      <div>{node.name}</div>
+      <button
+        data-testid={`folder-select-${node.id}`}
+        onClick={() => onNodeClick(node)}
+      >
+        select
+      </button>
+      {selectedNodeId === node.id && (
+        <span data-testid={`selected-${node.id}`}>[selected]</span>
+      )}
+    </li>
+  ),
+}));
+
+vi.mock("../../components/FileContentCard/FileContentCardRead", () => ({
+  __esModule: true,
+  default: ({ node }: any) => (
+    <div data-testid="file-card">content:{node.content}</div>
+  ),
+}));
+
+vi.mock("../../components/Header/Header", () => ({
+  __esModule: true,
+  default: () => <header data-testid="header" />,
+}));
+
+// Mock motion
+vi.mock("framer-motion", () => ({
+  motion: new Proxy({}, { get: () => (p: any) => <div {...p} /> }),
+}));
+
+// Mock services
+const getProjectById = vi.fn();
+const getOrCreateNodeContent = vi.fn();
+const getNodeContentById = vi.fn();
+vi.mock("../../utils/ProjectService", () => ({
+  ProjectService: {
+    getProjectById: (...a: any[]) => getProjectById(...a),
+  },
+}));
+vi.mock("../../utils/NodeContentService", () => ({
+  NodeContentService: {
+    getOrCreateNodeContent: (...a: any[]) => getOrCreateNodeContent(...a),
+    getNodeContentById: (...a: any[]) => getNodeContentById(...a),
+  },
+}));
+
+// Mock router params
+vi.mock("react-router-dom", async (orig) => {
+  const actual = await (orig as any)();
+  return { ...actual, useParams: () => ({ projectId: "p1" }) };
+});
+
+// LocalStorage mock
+const store = new Map<string, string>();
+beforeAll(() => {
+  vi.spyOn(window, "localStorage", "get").mockReturnValue({
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    length: 0,
+  } as any);
+});
+
+describe("ReadingPage", () => {
+  beforeEach(() => {
+    store.clear();
+    vi.clearAllMocks();
+
+    getProjectById.mockResolvedValue({
+      _id: "p1",
+      name: "Proj",
+      projectStructure: [
+        { id: "1", name: "Chapter structure", nodes: [] },
+        { id: "2", name: "Intro", nodes: [] },
+      ],
+    });
+
+    getOrCreateNodeContent.mockResolvedValue({
+      nodeId: "2",
+      content: "intro-content",
+      name: "Intro",
+      category: "cat",
+    });
+
+    getNodeContentById.mockResolvedValue({
+      nodeId: "2",
+      content: "intro-content",
+      name: "Intro",
+      category: "cat",
+    });
+  });
+
+  test("renders header and project structure", async () => {
+    render(<ReadingPage />);
+    await screen.findByTestId("header");
+
+    expect(screen.getByTestId("folder-1")).toBeInTheDocument();
+    expect(screen.getByTestId("folder-2")).toBeInTheDocument();
+  });
+
+  test("clicking a content node loads content and persists selected id", async () => {
+    render(<ReadingPage />);
+    await screen.findByText("Intro");
+
+    fireEvent.click(screen.getByTestId("folder-select-2"));
+
+    await waitFor(() => expect(getOrCreateNodeContent).toHaveBeenCalled());
+    expect(store.get("selectedNodeId_p1")).toBe("2");
+    expect(await screen.findByTestId("file-card")).toHaveTextContent(
+      "intro-content"
+    );
+  });
+
+  test("ignores click on root 'Chapter structure'", async () => {
+    render(<ReadingPage />);
+    await screen.findByText("Intro");
+
+    fireEvent.click(screen.getByTestId("folder-select-1"));
+    expect(getOrCreateNodeContent).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(/Select an element on the left/i)
+    ).toBeInTheDocument();
+  });
+
+  test("menuOpen restored from localStorage", async () => {
+    store.set("menuOpen", JSON.stringify(false));
+    render(<ReadingPage />);
+    await screen.findByTestId("header");
+
+    // Sidebar should be collapsed -> no folder items
+    expect(screen.queryByTestId("folder-1")).not.toBeInTheDocument();
+  });
+
+  test("toggle menuOpen updates localStorage", async () => {
+    render(<ReadingPage />);
+    await screen.findByTestId("folder-1");
+
+    // Find toggle button (Bars3Icon wrapper)
+    const toggleBtn = screen
+      .getAllByRole("button")
+      .find((b) => b.querySelector("svg"));
+    fireEvent.click(toggleBtn!);
+
+    expect(JSON.parse(store.get("menuOpen")!)).toBe(false);
+  });
+
+  test("restores selected node from localStorage and shows FileContentCardRead", async () => {
+    store.set("selectedNodeId_p1", "2");
+    render(<ReadingPage />);
+    await waitFor(() =>
+      expect(getNodeContentById).toHaveBeenCalledWith("2", "p1")
+    );
+    expect(await screen.findByTestId("file-card")).toBeInTheDocument();
+  });
+
+  test("shows 'Unknown view selected' for non-file view", async () => {
+    store.set("selectedNodeId_p1", "2");
+    store.set("activeView", "something-else");
+    render(<ReadingPage />);
+
+    await waitFor(() => expect(getNodeContentById).toHaveBeenCalled());
+    expect(
+      await screen.findByText(/Unknown view selected/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/ReadingPage/ReadingPage.test.tsx
+++ b/src/pages/ReadingPage/ReadingPage.test.tsx
@@ -123,7 +123,7 @@ describe("ReadingPage", () => {
     await waitFor(() => expect(getOrCreateNodeContent).toHaveBeenCalled());
     expect(store.get("selectedNodeId_p1")).toBe("2");
     expect(await screen.findByTestId("file-card")).toHaveTextContent(
-      "intro-content"
+      "intro-content",
     );
   });
 
@@ -134,7 +134,7 @@ describe("ReadingPage", () => {
     fireEvent.click(screen.getByTestId("folder-select-1"));
     expect(getOrCreateNodeContent).not.toHaveBeenCalled();
     expect(
-      screen.getByText(/Select an element on the left/i)
+      screen.getByText(/Select an element on the left/i),
     ).toBeInTheDocument();
   });
 
@@ -164,7 +164,7 @@ describe("ReadingPage", () => {
     store.set("selectedNodeId_p1", "2");
     render(<ReadingPage />);
     await waitFor(() =>
-      expect(getNodeContentById).toHaveBeenCalledWith("2", "p1")
+      expect(getNodeContentById).toHaveBeenCalledWith("2", "p1"),
     );
     expect(await screen.findByTestId("file-card")).toBeInTheDocument();
   });
@@ -176,7 +176,7 @@ describe("ReadingPage", () => {
 
     await waitFor(() => expect(getNodeContentById).toHaveBeenCalled());
     expect(
-      await screen.findByText(/Unknown view selected/i)
+      await screen.findByText(/Unknown view selected/i),
     ).toBeInTheDocument();
   });
 });

--- a/src/pages/ReadingPage/ReadingPage.tsx
+++ b/src/pages/ReadingPage/ReadingPage.tsx
@@ -1,0 +1,161 @@
+import { useState, useEffect } from "react";
+import "../../App/App.css";
+import FolderRead from "../../components/Folder/FolderRead";
+import FileContentCardRead from "../../components/FileContentCard/FileContentCardRead";
+import { Bars3Icon } from "@heroicons/react/24/solid";
+import { Node, Project } from "../../utils/types";
+import Header from "../../components/Header/Header";
+import { NodeContentService } from "../../utils/NodeContentService";
+import { ProjectService } from "../../utils/ProjectService";
+import { useParams } from "react-router-dom";
+import { motion } from "framer-motion";
+
+const ReadingPage = () => {
+  const { projectId } = useParams<{ projectId: string }>();
+
+  const [nodes, setNodes] = useState<Node[]>([]);
+  const [selectedNode, setSelectedNode] = useState<Node | null>(null);
+
+  const [menuOpen, setMenuOpen] = useState<boolean>(() => {
+    const savedMenuOpen = localStorage.getItem("menuOpen");
+    return savedMenuOpen ? JSON.parse(savedMenuOpen) : true;
+  });
+
+  const [activeView, setActiveView] = useState(() => {
+    const savedView = localStorage.getItem("activeView");
+    return savedView ? savedView : "file";
+  });
+
+  useEffect(() => {
+    localStorage.setItem("activeView", activeView);
+  }, [activeView]);
+
+  useEffect(() => {
+    if (projectId) {
+      ProjectService.getProjectById(projectId)
+        .then((project: Project) => {
+          if (Array.isArray(project.projectStructure)) {
+            setNodes(project.projectStructure);
+          }
+        })
+        .catch((error) => console.error("Error fetching project:", error));
+    }
+
+    const savedNodeId = projectId
+      ? localStorage.getItem(`selectedNodeId_${projectId}`)
+      : null;
+    if (savedNodeId && projectId) {
+      NodeContentService.getNodeContentById(savedNodeId, projectId)
+        .then((nodeContent) => {
+          if (nodeContent) {
+            setSelectedNode({
+              id: nodeContent.nodeId || "",
+              name: nodeContent.name,
+              content: nodeContent.content,
+              category: nodeContent.category,
+            });
+          }
+        })
+        .catch((error) => console.error("Error fetching node content:", error));
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    localStorage.setItem("menuOpen", JSON.stringify(menuOpen));
+  }, [menuOpen]);
+
+  const handleNodeClick = async (node: Node) => {
+    if (node.name === "Chapter structure") return;
+    try {
+      if (!projectId) return;
+      const nodeContent = await NodeContentService.getOrCreateNodeContent({
+        ...node,
+        projectId,
+      });
+      const fullNode = { ...node, content: nodeContent.content };
+      setSelectedNode(fullNode);
+      localStorage.setItem(`selectedNodeId_${projectId}`, node.id);
+      setActiveView("file");
+    } catch (error) {
+      console.error("Error loading node content:", error);
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-screen bg-[#e0dbf4] text-[#362466] dark:bg-[#090325] dark:text-white relative overflow-x-hidden">
+      <Header />
+
+      <div className="flex flex-1 relative">
+        {/* Sidebar */}
+        <div
+          className={`sticky top-0 left-0 h-screen ${
+            menuOpen ? "w-1/4" : "w-19"
+          } transition-all duration-500 flex flex-col relative`}
+        >
+          <div className="bg-[#f4f2fa] dark:bg-[#1e1538] py-2 px-4 flex h-full flex-col justify-between shadow-[inset_0_0_30px_rgba(120,69,239,0.55)] dark:shadow-[inset_0_0_30px_rgba(120,69,239,0.25)] pt-14">
+            <button
+              onClick={() => setMenuOpen(!menuOpen)}
+              className="mb-2 py-1 mt-2 px-3 rounded-full hover:bg-[#dedbf0] dark:hover:bg-[#373254] transition cursor-pointer"
+            >
+              <Bars3Icon className="h-6 w-6 text-[#473885] dark:text-[#c4b5fd]" />
+            </button>
+
+            {menuOpen && (
+              <ul className="flex-1 space-y-2 overflow-y-auto no-scrollbar px-2">
+                {nodes.map((node) => (
+                  <FolderRead
+                    key={node.id}
+                    node={node}
+                    onNodeClick={handleNodeClick}
+                    selectedNodeId={selectedNode?.id}
+                  />
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+
+        {/* Content */}
+        <main
+          className={`${
+            menuOpen ? "w-3/4" : "w-full"
+          } transition-all duration-300 p-6 pt-20`}
+        >
+          <motion.div
+            initial={{ backgroundPosition: "0% 0%" }}
+            animate={{ backgroundPosition: ["0% 0%", "100% 100%", "0% 0%"] }}
+            transition={{ repeat: Infinity, duration: 8, ease: "linear" }}
+            className="p-[4px] rounded-3xl shadow-[0_0_20px_rgba(120,69,239,0.3)] dark:shadow-[0_0_30px_rgba(120,69,239,0.25)] h-full"
+            style={{
+              backgroundImage:
+                "linear-gradient(180deg, #7c3aed, #db2777, #facc15)",
+              backgroundSize: "200% 200%",
+            }}
+          >
+            <div className="bg-[#e9e5f8] dark:bg-[#1e1538] rounded-3xl h-full shadow-[0_0_14px_rgba(120,69,239,0.4)] dark:shadow-[0_0_40px_rgba(120,69,239,0.3)] flex flex-col">
+              {selectedNode ? (
+                activeView === "file" ? (
+                  <FileContentCardRead node={selectedNode} />
+                ) : (
+                  <div className="flex h-full items-center justify-center">
+                    <p className="text-xl text-[#261e3b] dark:text-[#aaa6c3] leading-relaxed">
+                      Unknown view selected.
+                    </p>
+                  </div>
+                )
+              ) : (
+                <div className="flex h-full items-center justify-center">
+                  <p className="text-xl text-[#261e3b] dark:text-[#aaa6c3] leading-relaxed">
+                    Select an element on the left to view its content.
+                  </p>
+                </div>
+              )}
+            </div>
+          </motion.div>
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default ReadingPage;

--- a/src/pages/StructureSelectionPage/StructureSelectionPage.tsx
+++ b/src/pages/StructureSelectionPage/StructureSelectionPage.tsx
@@ -21,7 +21,7 @@ const StructureSelectionPage = () => {
 
   const [projectName, setProjectName] = useState("");
   const [selectedStructure, setSelectedStructure] = useState<string | null>(
-    null,
+    null
   );
 
   const handleSave = async () => {
@@ -65,6 +65,7 @@ const StructureSelectionPage = () => {
         name: projectName,
         username: user?.username || user?.id || "unknown-user",
         projectStructure: projectStructure,
+        isPublic: false,
       });
 
       navigate(`/edit/${createdProject._id}`);
@@ -85,7 +86,7 @@ const StructureSelectionPage = () => {
             boxShadow: "0 4px 12px rgba(255, 0, 80, 0.1)",
             border: "1px solid #ef4444",
           },
-        },
+        }
       );
     }
   };

--- a/src/pages/StructureSelectionPage/StructureSelectionPage.tsx
+++ b/src/pages/StructureSelectionPage/StructureSelectionPage.tsx
@@ -21,7 +21,7 @@ const StructureSelectionPage = () => {
 
   const [projectName, setProjectName] = useState("");
   const [selectedStructure, setSelectedStructure] = useState<string | null>(
-    null
+    null,
   );
 
   const handleSave = async () => {
@@ -86,7 +86,7 @@ const StructureSelectionPage = () => {
             boxShadow: "0 4px 12px rgba(255, 0, 80, 0.1)",
             border: "1px solid #ef4444",
           },
-        }
+        },
       );
     }
   };

--- a/src/utils/ProjectService.test.ts
+++ b/src/utils/ProjectService.test.ts
@@ -41,6 +41,7 @@ describe("ProjectService", () => {
         name: "Test Project",
         username: "alice",
         projectStructure: [],
+        isPublic: false,
       };
 
       const created: Project = {
@@ -67,6 +68,7 @@ describe("ProjectService", () => {
           name: "X",
           username: "y",
           projectStructure: [],
+          isPublic: false,
         }),
       ).rejects.toThrow(err);
 
@@ -81,6 +83,7 @@ describe("ProjectService", () => {
         name: "Proj",
         username: "bob",
         projectStructure: [],
+        isPublic: false,
       };
       mockedAxios.get.mockResolvedValueOnce(makeAxiosResponse(project));
 
@@ -108,6 +111,7 @@ describe("ProjectService", () => {
         name: "Updated",
         username: "bob",
         projectStructure: [],
+        isPublic: false,
       };
 
       mockedAxios.put.mockResolvedValueOnce(makeAxiosResponse(updated));
@@ -134,8 +138,20 @@ describe("ProjectService", () => {
   describe("getProjectsByUsername", () => {
     it("fetches projects by username", async () => {
       const projects: Project[] = [
-        { _id: "1", name: "P1", username: "bob", projectStructure: [] },
-        { _id: "2", name: "P2", username: "bob", projectStructure: [] },
+        {
+          _id: "1",
+          name: "P1",
+          username: "bob",
+          projectStructure: [],
+          isPublic: false,
+        },
+        {
+          _id: "2",
+          name: "P2",
+          username: "bob",
+          projectStructure: [],
+          isPublic: false,
+        },
       ];
       mockedAxios.get.mockResolvedValueOnce(makeAxiosResponse(projects));
 
@@ -177,7 +193,13 @@ describe("ProjectService", () => {
   describe("getRecentProjectsByUsername", () => {
     it("fetches recent projects", async () => {
       const projects: Project[] = [
-        { _id: "3", name: "Recent", username: "bob", projectStructure: [] },
+        {
+          _id: "3",
+          name: "Recent",
+          username: "bob",
+          projectStructure: [],
+          isPublic: false,
+        },
       ];
       mockedAxios.get.mockResolvedValueOnce(makeAxiosResponse(projects));
 

--- a/src/utils/types.test.ts
+++ b/src/utils/types.test.ts
@@ -50,11 +50,12 @@ describe("Project type", () => {
       name: "My Project",
       username: "alice",
       projectStructure: [],
+      isPublic: false,
     };
     // check required props
     expectTypeOf(project.name).toEqualTypeOf<string>();
     expectTypeOf(project.username).toEqualTypeOf<string>();
-    expectTypeOf(project.projectStructure).toEqualTypeOf<Node[]>();
+    expectTypeOf(project.projectStructure).items.toMatchTypeOf<Node>();
   });
 
   it("should allow optional fields", () => {
@@ -65,6 +66,7 @@ describe("Project type", () => {
       projectStructure: [],
       createdAt: "2024-01-01T00:00:00Z",
       updatedAt: "2024-01-02T00:00:00Z",
+      isPublic: false,
     };
     // optional fields should be strings (when present)
     expectTypeOf(project._id).toEqualTypeOf<string | undefined>();

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -24,7 +24,13 @@ export interface Project {
   _id?: string;
   name: string;
   username: string;
-  projectStructure: Node[];
+  projectStructure: Node[] | object; // optional: Mixed wie im Schema
+  isPublic: boolean;                // neu: public/private toggle
+  tags?: string[];                  // neu: Tags
+  titleCommunityPage?: string;      // neu: Community Page Title
+  category?: string;                // neu: Kategorie
+  typeOfDocument?: string;          // neu: Dokumenttyp
   createdAt?: string;
   updatedAt?: string;
+  authorName?: string;             // Optional: Name des Autors
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -25,12 +25,12 @@ export interface Project {
   name: string;
   username: string;
   projectStructure: Node[] | object; // optional: Mixed wie im Schema
-  isPublic: boolean;                // neu: public/private toggle
-  tags?: string[];                  // neu: Tags
-  titleCommunityPage?: string;      // neu: Community Page Title
-  category?: string;                // neu: Kategorie
-  typeOfDocument?: string;          // neu: Dokumenttyp
+  isPublic: boolean; // neu: public/private toggle
+  tags?: string[]; // neu: Tags
+  titleCommunityPage?: string; // neu: Community Page Title
+  category?: string; // neu: Kategorie
+  typeOfDocument?: string; // neu: Dokumenttyp
   createdAt?: string;
   updatedAt?: string;
-  authorName?: string;             // Optional: Name des Autors
+  authorName?: string; // Optional: Name des Autors
 }


### PR DESCRIPTION
This PR introduces updates to the Edit Page for Community Page Settings (accessible via Bottom Navigation Bar → third button).

* Ability to toggle public/private status of a project (default: private; requires the document to be published; can be reverted back to private).
* Support for editing tags, title, category (e.g., Computer Science, …), and type of document (e.g., Bachelor Thesis, PTB, …).
* Option to mark a project as anonymous.

All new fields are stored within the project object in the database.

**Note for setup:**

* **Since the Project model has changed, the existing database container and volume need to be removed. A new container can be created using mongoDB/docker-compose.yml with: `docker compose up -d`**

Here is an overview of the fields in the project object (probably relevant for Lisa):

* name: string – internal project name (private view).
* username: string – creator’s username.
* projectStructure: object – internal project structure.
* isPublic: boolean – important: true → document is public. | false → document is private.
* tags: string[] – list of keywords (e.g., ["docker", "flutter", "bacteria"]).
* titleCommunityPage: string – title shown on the public document page (can differ from name).
* category: string – e.g., Computer Science.
* typeOfDocument: string – e.g., Bachelor Thesis, PTB.
* authorName: string – either the username or "Anonymous" if "post as Anonymous" was selected.
* created_at: Date.
* updated_at: Date.

Screenshot: <img width="1427" height="847" alt="image" src="https://github.com/user-attachments/assets/3f4f0ebd-49d1-4f21-80bf-bbe1edea1ad7" />

---

### Extension: ReadingPage

This PR was extended by adding the **ReadingPage**, which is displayed when users open other people’s projects via the Community Page.

* The ReadingPage is **read-only**: users can only view content, not edit.
* Read-only versions of the `Folder` and `FileContentCard` components were created.
* The view is invoked almost the same way as the EditPage, but with `/read` instead of `/edit`.

**App routes:**

```tsx
<Route path="/edit/:projectId" element={<EditPage />} />
<Route path="/read/:projectId" element={<ReadingPage />} />
```

**Examples:**

- [http://localhost:5173/edit/68dd2a96903271b32b094bcf](http://localhost:5173/edit/68dd2a96903271b32b094bcf)
- [http://localhost:5173/read/68dd2a96903271b32b094bcf](http://localhost:5173/read/68dd2a96903271b32b094bcf)




